### PR TITLE
chore: align scaffold docs and ACM dependency

### DIFF
--- a/.boilerplate/terragrunt.hcl
+++ b/.boilerplate/terragrunt.hcl
@@ -73,7 +73,7 @@ terraform {
 inputs = {
   is_hub     = {{ .is_hub }}
   org        = local.env_vars.org
-  spoke_def  = local.spoke_vars.spoke_def
+  spoke_def  = local.spoke_vars.spoke
   {{- range .requiredVariables }}
   {{- if ne .Name "org" }}
   {{- if eq .Name "domain_zone"}}

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ terraform {
 inputs = {
   is_hub     = false
   org        = local.env_vars.org
-  spoke_def  = local.spoke_vars.spoke_def
+  spoke_def  = local.spoke_vars.spoke
   domain_zone = try(local.local_vars.api_gateway.zone, local.local_vars.domain_zone)
   name_prefix = try(local.local_vars.name_prefix, "")
   apigw_domains = try(local.local_vars.api_gateway.domains, local.local_vars.apigw_domains, [])
@@ -400,13 +400,13 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.43.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_certificates"></a> [certificates](#module\_certificates) | git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git | v1.2.10 |
+| <a name="module_certificates"></a> [certificates](#module\_certificates) | git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git | v1.3.6 |
 | <a name="module_tags"></a> [tags](#module\_tags) | cloudopsworks/tags/local | 1.0.9 |
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.43.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
 
 ## Modules
 

--- a/README.yaml
+++ b/README.yaml
@@ -223,7 +223,7 @@ usage: |-
   inputs = {
     is_hub     = false
     org        = local.env_vars.org
-    spoke_def  = local.spoke_vars.spoke_def
+    spoke_def  = local.spoke_vars.spoke
     domain_zone = try(local.local_vars.api_gateway.zone, local.local_vars.domain_zone)
     name_prefix = try(local.local_vars.name_prefix, "")
     apigw_domains = try(local.local_vars.api_gateway.domains, local.local_vars.apigw_domains, [])

--- a/acm.tf
+++ b/acm.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 module "certificates" {
-  source = "git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git?ref=v1.2.10"
+  source = "git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git?ref=v1.3.6"
   providers = {
     aws               = aws
     aws.cross_account = aws.cross_account

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.43.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,13 +9,13 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.43.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_certificates"></a> [certificates](#module\_certificates) | git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git | v1.2.10 |
+| <a name="module_certificates"></a> [certificates](#module\_certificates) | git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git | v1.3.6 |
 | <a name="module_tags"></a> [tags](#module\_tags) | cloudopsworks/tags/local | 1.0.9 |
 
 ## Resources


### PR DESCRIPTION
## Summary

- Update the ACM certificate child module pin to v1.3.6.
- Correct generated Terragrunt scaffold examples to read local.spoke_vars.spoke.
- Regenerate Terraform documentation after the dependency update.

+semver: patch